### PR TITLE
Fix integer sum inverse

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1776,7 +1776,7 @@ mod test {
 
     prop_compose! {
         /// generates integer_sum(?) - 1, integer_sum(?), and integer_sum(?) + 1.
-        fn inverse_boundary()(n in 0..(1usize<<31), d in 0usize..3) -> usize {
+        fn inverse_boundary()(n in 0..(((usize::MAX/2) as f64).sqrt() as usize), d in 0usize..3) -> usize {
             RotatedArraySet::<u8>::integer_sum(n)
                 .wrapping_add(d)
                 .wrapping_sub(1)

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1192,7 +1192,14 @@ where
     fn integer_sum_inverse(n: usize) -> usize {
         // y = (x * (x + 1)) / 2
         // x = (sqrt(8 * y + 1) - 1) / 2
-        ((f64::from((n * 8 + 1) as u32).sqrt() as usize) - 1) / 2
+        let floaty = ((n as f64 * 8.0 + 1.0).sqrt() - 1.0) / 2.0;
+        let tmp = floaty as usize;
+        let sum = Self::integer_sum(tmp);
+        if sum <= n {
+            tmp
+        } else {
+            tmp - 1
+        }
     }
 
     fn get_subarray_idx_from_array_idx(idx: usize) -> usize {


### PR DESCRIPTION
Hi, this is very interesting data structure! Thank you for the detailed explanation and implementation!

I found an issue that might case access to an unwanted position (either out-of-bounds or different element) of the underlying array when `RotatedArraySet` is used with a large number of elements (somewhere around 10^8 to 10^9). Maybe it'd be better to select other data structures that has logarithmic performance at that large scale, but here's a patch anyway.